### PR TITLE
Update navbar brand to use logo image

### DIFF
--- a/about.html
+++ b/about.html
@@ -30,7 +30,7 @@
     
 	  <nav class="navbar navbar-expand-lg navbar-dark ftco_navbar bg-dark ftco-navbar-light" id="ftco-navbar">
 	    <div class="container">
-	      <a class="navbar-brand" href="index.html">Even<span>talk.</span></a>
+            <a class="navbar-brand" href="index.html"><img src="images/logo.png" alt="Logo"></a>
 	      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#ftco-nav" aria-controls="ftco-nav" aria-expanded="false" aria-label="Toggle navigation">
 	        <span class="oi oi-menu"></span> Menu
 	      </button>

--- a/blog-single.html
+++ b/blog-single.html
@@ -30,7 +30,7 @@
     
 	  <nav class="navbar navbar-expand-lg navbar-dark ftco_navbar bg-dark ftco-navbar-light" id="ftco-navbar">
 	    <div class="container">
-	      <a class="navbar-brand" href="index.html">Even<span>talk.</span></a>
+            <a class="navbar-brand" href="index.html"><img src="images/logo.png" alt="Logo"></a>
 	      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#ftco-nav" aria-controls="ftco-nav" aria-expanded="false" aria-label="Toggle navigation">
 	        <span class="oi oi-menu"></span> Menu
 	      </button>

--- a/blog.html
+++ b/blog.html
@@ -30,7 +30,7 @@
     
 	  <nav class="navbar navbar-expand-lg navbar-dark ftco_navbar bg-dark ftco-navbar-light" id="ftco-navbar">
 	    <div class="container">
-	      <a class="navbar-brand" href="index.html">Even<span>talk.</span></a>
+            <a class="navbar-brand" href="index.html"><img src="images/logo.png" alt="Logo"></a>
 	      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#ftco-nav" aria-controls="ftco-nav" aria-expanded="false" aria-label="Toggle navigation">
 	        <span class="oi oi-menu"></span> Menu
 	      </button>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 	    <div class="container">
 	      
 	      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#ftco-nav" aria-controls="ftco-nav" aria-expanded="false" aria-label="Toggle navigation">
-			<a class="navbar-brand" href="index.html">Even<span>talk.</span></a>
+                        <a class="navbar-brand" href="index.html"><img src="images/logo.png" alt="Logo"></a>
 			<span class="oi oi-menu"></span> Menu
 	      </button>
 


### PR DESCRIPTION
## Summary
- use `images/logo.png` for the navbar brand in all pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845e67ecb7c8324a8f17376de69f71f