### PR TITLE
fix: manter fotos laterais e responsividade

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,18 @@ Os endereços das páginas serão exibidos ao final da execução.
 
 Para publicar o conteúdo do site em cada blob, utilize o script `scripts/deploy.sh` ou a *GitHub Action* definida em `.github/workflows/deploy.yml`. Defina a variável de ambiente `STORAGE_ACCOUNTS` com os nomes das contas separados por vírgula.
 O workflow seleciona automaticamente o arquivo `.tfvars` de acordo com o ramo `dev`, `hml` ou `main`.
+
+### Formato do segredo do Service Principal
+
+Defina o segredo `AZURE_CREDENTIALS` no GitHub com as credenciais do Service Principal no seguinte formato JSON:
+
+```json
+{
+  "clientId": "APP_ID",
+  "clientSecret": "PASSWORD",
+  "subscriptionId": "SUBSCRIPTION_ID",
+  "tenantId": "TENANT_ID"
+}
+```
+
+Este segredo é utilizado pelo action `azure/login` para autenticar no Azure durante o deploy.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -284,7 +284,7 @@ body {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: center;
+    object-position: top;
 }
 
 .flag-icon {
@@ -353,6 +353,13 @@ body {
     flex-shrink: 0;
     display: flex;
     align-items: stretch;
+}
+
+@media (max-width: 575.98px) {
+    #organizacao .speaker-img-container,
+    #convidados .speaker-img-container {
+        width: 100px;
+    }
 }
 
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -355,14 +355,6 @@ body {
     align-items: stretch;
 }
 
-@media (max-width: 767.98px) {
-    #organizacao .speaker-img-container,
-    #convidados .speaker-img-container {
-        width: 100% !important;
-        height: 180px !important;
-        border-radius: 0.5rem 0.5rem 0 0;
-    }
-}
 
 .speaker-img-wrapper {
     height: 220px;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -284,7 +284,7 @@ body {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    object-position: top;
+    object-position: center;
 }
 
 .flag-icon {
@@ -355,14 +355,7 @@ body {
     align-items: stretch;
 }
 
-@media (max-width: 575.98px) {
-    #organizacao .speaker-img-container,
-    #convidados .speaker-img-container {
-        width: 100% !important;
-        height: 180px !important;
-        border-radius: 0.5rem 0.5rem 0 0;
-    }
-}
+
 
 
 .speaker-img-wrapper {
@@ -371,4 +364,8 @@ body {
     border-top-left-radius: 0.5rem;
     border-top-right-radius: 0.5rem;
 }
-.img-cover-h220 {\n    width: 100%;\n    height: 220px;\n    object-fit: cover;\n}
+.img-cover-h220 {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -355,6 +355,15 @@ body {
     align-items: stretch;
 }
 
+@media (max-width: 575.98px) {
+    #organizacao .speaker-img-container,
+    #convidados .speaker-img-container {
+        width: 100% !important;
+        height: 180px !important;
+        border-radius: 0.5rem 0.5rem 0 0;
+    }
+}
+
 
 .speaker-img-wrapper {
     height: 220px;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -346,7 +346,8 @@ body {
     }
 }
 .speaker-img-container {
-    width: 140px;
+    flex: 0 0 35%;
+    max-width: 140px;
     height: 100%;
     overflow: hidden;
     border-radius: 0 0.5rem 0.5rem 0;
@@ -358,7 +359,8 @@ body {
 @media (max-width: 575.98px) {
     #organizacao .speaker-img-container,
     #convidados .speaker-img-container {
-        width: 100px;
+        flex-basis: 30%;
+        max-width: 120px;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 			</p>
 			<div class="row justify-content-center g-4">
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_1.png" class="img-cover-top" alt="Cláudio Raposo" loading="lazy">
                                                 </div>
@@ -177,7 +177,7 @@
 					</article>
 				</div>
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_2.jpg" class="img-cover-top" alt="José Quintino" loading="lazy">
                                                 </div>
@@ -194,7 +194,7 @@
 					</article>
 				</div>
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_3.jpg" class="img-cover-top" alt="Marcelo Pacífico" loading="lazy">
                                                 </div>
@@ -220,7 +220,7 @@
 			<h2 class="section-title mb-4">Convidados</h2>
                         <div class="row">
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/32.jpg" class="img-cover-top" alt="João Silva" loading="lazy">
                                                 </div>
@@ -231,7 +231,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/45.jpg" class="img-cover-top" alt="Carlos Mendes" loading="lazy">
                                                 </div>
@@ -242,7 +242,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/54.jpg" class="img-cover-top" alt="António Sousa" loading="lazy">
                                                 </div>
@@ -253,7 +253,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/67.jpg" class="img-cover-top" alt="Miguel Machava" loading="lazy">
                                                 </div>

--- a/index.html
+++ b/index.html
@@ -158,9 +158,9 @@
 				Equipe dedicada à realização do BACC, promovendo integração e inovação entre Brasil, Angola e países
 				lusófonos. Conheça nossos organizadores e parceiros que tornam este evento possível.
 			</p>
-			<div class="row justify-content-center g-4">
-                                <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+            <div class="row justify-content-center g-4">
+                <div class="col-md-4">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_1.png" class="img-cover-top" alt="Cláudio Raposo" loading="lazy">
                                                 </div>
@@ -176,8 +176,8 @@
 						</div>
 					</article>
 				</div>
-                                <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                <div class="col-md-4">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_2.jpg" class="img-cover-top" alt="José Quintino" loading="lazy">
                                                 </div>
@@ -193,8 +193,8 @@
 						</div>
 					</article>
 				</div>
-                                <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                <div class="col-md-4">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_3.jpg" class="img-cover-top" alt="Marcelo Pacífico" loading="lazy">
                                                 </div>
@@ -220,7 +220,7 @@
 			<h2 class="section-title mb-4">Convidados</h2>
                         <div class="row">
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/32.jpg" class="img-cover-top" alt="João Silva" loading="lazy">
                                                 </div>
@@ -231,7 +231,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/45.jpg" class="img-cover-top" alt="Carlos Mendes" loading="lazy">
                                                 </div>
@@ -242,7 +242,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/54.jpg" class="img-cover-top" alt="António Sousa" loading="lazy">
                                                 </div>
@@ -253,7 +253,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/67.jpg" class="img-cover-top" alt="Miguel Machava" loading="lazy">
                                                 </div>

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 			</p>
 			<div class="row justify-content-center g-4">
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_1.png" class="img-cover-top" alt="Cláudio Raposo" loading="lazy">
                                                 </div>
@@ -177,7 +177,7 @@
 					</article>
 				</div>
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_2.jpg" class="img-cover-top" alt="José Quintino" loading="lazy">
                                                 </div>
@@ -194,7 +194,7 @@
 					</article>
 				</div>
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_3.jpg" class="img-cover-top" alt="Marcelo Pacífico" loading="lazy">
                                                 </div>
@@ -220,7 +220,7 @@
 			<h2 class="section-title mb-4">Convidados</h2>
                         <div class="row">
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/32.jpg" class="img-cover-top" alt="João Silva" loading="lazy">
                                                 </div>
@@ -231,7 +231,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/45.jpg" class="img-cover-top" alt="Carlos Mendes" loading="lazy">
                                                 </div>
@@ -242,7 +242,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/54.jpg" class="img-cover-top" alt="António Sousa" loading="lazy">
                                                 </div>
@@ -253,7 +253,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/67.jpg" class="img-cover-top" alt="Miguel Machava" loading="lazy">
                                                 </div>

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
 			</p>
 			<div class="row justify-content-center g-4">
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_1.png" class="img-cover-top" alt="Cláudio Raposo" loading="lazy">
                                                 </div>
@@ -177,7 +177,7 @@
 					</article>
 				</div>
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_2.jpg" class="img-cover-top" alt="José Quintino" loading="lazy">
                                                 </div>
@@ -194,7 +194,7 @@
 					</article>
 				</div>
                                 <div class="col-md-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="assets/images/org_3.jpg" class="img-cover-top" alt="Marcelo Pacífico" loading="lazy">
                                                 </div>
@@ -220,7 +220,7 @@
 			<h2 class="section-title mb-4">Convidados</h2>
                         <div class="row">
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/32.jpg" class="img-cover-top" alt="João Silva" loading="lazy">
                                                 </div>
@@ -231,7 +231,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/45.jpg" class="img-cover-top" alt="Carlos Mendes" loading="lazy">
                                                 </div>
@@ -242,7 +242,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/54.jpg" class="img-cover-top" alt="António Sousa" loading="lazy">
                                                 </div>
@@ -253,7 +253,7 @@
                                         </article>
                                 </div>
                                 <div class="col-lg-3 col-md-6 mb-4">
-                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                                        <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                                                 <div class="speaker-img-container">
                                                         <img src="https://randomuser.me/api/portraits/men/67.jpg" class="img-cover-top" alt="Miguel Machava" loading="lazy">
                                                 </div>

--- a/pages/fall-2025.html
+++ b/pages/fall-2025.html
@@ -180,7 +180,7 @@
             </p>
             <div class="row justify-content-center g-4">
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall1.png" class="img-cover-top" alt="Cláudio Raposo" loading="lazy">
                         </div>
@@ -197,7 +197,7 @@
                     </article>
                 </div>
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall2.png" class="img-cover-top" alt="José Quintino" loading="lazy">
                         </div>
@@ -214,7 +214,7 @@
                     </article>
                 </div>
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall3.png" class="img-cover-top" alt="Marcelo Pacífico" loading="lazy">
                         </div>
@@ -240,7 +240,7 @@
             <h2 class="section-title mb-4">Convidados</h2>
             <div class="row">
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/32.jpg" class="img-cover-top" alt="João Silva" loading="lazy">
                         </div>
@@ -251,7 +251,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/45.jpg" class="img-cover-top" alt="Carlos Mendes" loading="lazy">
                         </div>
@@ -262,7 +262,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/54.jpg" class="img-cover-top" alt="António Sousa" loading="lazy">
                         </div>
@@ -273,7 +273,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-md-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/67.jpg" class="img-cover-top" alt="Miguel Machava" loading="lazy">
                         </div>

--- a/pages/fall-2025.html
+++ b/pages/fall-2025.html
@@ -180,7 +180,7 @@
             </p>
             <div class="row justify-content-center g-4">
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall1.png" class="img-cover-top" alt="Cláudio Raposo" loading="lazy">
                         </div>
@@ -197,7 +197,7 @@
                     </article>
                 </div>
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall2.png" class="img-cover-top" alt="José Quintino" loading="lazy">
                         </div>
@@ -214,7 +214,7 @@
                     </article>
                 </div>
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall3.png" class="img-cover-top" alt="Marcelo Pacífico" loading="lazy">
                         </div>
@@ -240,7 +240,7 @@
             <h2 class="section-title mb-4">Convidados</h2>
             <div class="row">
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/32.jpg" class="img-cover-top" alt="João Silva" loading="lazy">
                         </div>
@@ -251,7 +251,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/45.jpg" class="img-cover-top" alt="Carlos Mendes" loading="lazy">
                         </div>
@@ -262,7 +262,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/54.jpg" class="img-cover-top" alt="António Sousa" loading="lazy">
                         </div>
@@ -273,7 +273,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 d-flex flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/67.jpg" class="img-cover-top" alt="Miguel Machava" loading="lazy">
                         </div>

--- a/pages/fall-2025.html
+++ b/pages/fall-2025.html
@@ -180,7 +180,7 @@
             </p>
             <div class="row justify-content-center g-4">
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall1.png" class="img-cover-top" alt="Cláudio Raposo" loading="lazy">
                         </div>
@@ -197,7 +197,7 @@
                     </article>
                 </div>
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall2.png" class="img-cover-top" alt="José Quintino" loading="lazy">
                         </div>
@@ -214,7 +214,7 @@
                     </article>
                 </div>
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall3.png" class="img-cover-top" alt="Marcelo Pacífico" loading="lazy">
                         </div>
@@ -240,7 +240,7 @@
             <h2 class="section-title mb-4">Convidados</h2>
             <div class="row">
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/32.jpg" class="img-cover-top" alt="João Silva" loading="lazy">
                         </div>
@@ -251,7 +251,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/45.jpg" class="img-cover-top" alt="Carlos Mendes" loading="lazy">
                         </div>
@@ -262,7 +262,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/54.jpg" class="img-cover-top" alt="António Sousa" loading="lazy">
                         </div>
@@ -273,7 +273,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/67.jpg" class="img-cover-top" alt="Miguel Machava" loading="lazy">
                         </div>

--- a/pages/fall-2025.html
+++ b/pages/fall-2025.html
@@ -180,7 +180,7 @@
             </p>
             <div class="row justify-content-center g-4">
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall1.png" class="img-cover-top" alt="Cláudio Raposo" loading="lazy">
                         </div>
@@ -197,7 +197,7 @@
                     </article>
                 </div>
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall2.png" class="img-cover-top" alt="José Quintino" loading="lazy">
                         </div>
@@ -214,7 +214,7 @@
                     </article>
                 </div>
                 <div class="col-md-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="../assets/images/org_fall3.png" class="img-cover-top" alt="Marcelo Pacífico" loading="lazy">
                         </div>
@@ -240,7 +240,7 @@
             <h2 class="section-title mb-4">Convidados</h2>
             <div class="row">
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/32.jpg" class="img-cover-top" alt="João Silva" loading="lazy">
                         </div>
@@ -251,7 +251,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/45.jpg" class="img-cover-top" alt="Carlos Mendes" loading="lazy">
                         </div>
@@ -262,7 +262,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/54.jpg" class="img-cover-top" alt="António Sousa" loading="lazy">
                         </div>
@@ -273,7 +273,7 @@
                     </article>
                 </div>
                 <div class="col-lg-3 col-md-6 mb-4">
-                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-row-reverse align-items-stretch speaker-card-bg">
+                    <article data-animate="fadeInUp" class="card shadow-lg h-100 flex-column flex-sm-row-reverse align-items-stretch speaker-card-bg">
                         <div class="speaker-img-container">
                             <img src="https://randomuser.me/api/portraits/men/67.jpg" class="img-cover-top" alt="Miguel Machava" loading="lazy">
                         </div>


### PR DESCRIPTION
## Summary
- remover media query que alterava a largura das imagens
- manter layout lateral para cards de palestrantes e convidados
- exemplo de segredo `AZURE_CREDENTIALS` já incluso no README

## Testing
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848bfedb4748324b8faea6fd6e322c1